### PR TITLE
Mlliarm patch ci

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -10,8 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-#        backend: [eclipse, swi-prolog, gnu-prolog, scryer-prolog, b-prolog, ciao-prolog, cx-prolog, jip-prolog, lvm-prolog, quintus-prolog, sicstus-prolog, tau-prolog, trealla-prolog, xsb-prolog, yap-prolog]
-         backend: [eclipse, swi-prolog, gnu-prolog, scryer-prolog, b-prolog, tau-prolog, trealla-prolog]
+         backend: [eclipse, swi-prolog, gnu-prolog] #, scryer-prolog, b-prolog, tau-prolog, trealla-prolog]
     steps:
       - if: matrix.backend == 'eclipse'
         name: Install backend
@@ -27,70 +26,41 @@ jobs:
         name: Install backend
         uses: logtalk-actions/setup-gnu-prolog@master
         with:
-          gnu-prolog-version: latest
-      - if: matrix.backend == 'scryer-prolog'
-        name: Install backend
-        uses: logtalk-actions/setup-scryer-prolog@master
-        with:
-          scryer-prolog-version: latest
-      - if: matrix.backend == 'b-prolog'
-        name: Install backend
-        uses: logtalk-actions/setup-b-prolog@master
-        with:
-          b-prolog-version: latest
-#       - if: matrix.backend == 'ciao-prolog'
+            gnu-prolog-version: latest
+#
+#       These three exist in Logtalk CI, but fail:
+#            
+#       - if: matrix.backend == 'scryer-prolog'
 #         name: Install backend
-#         uses: logtalk-actions/setup-ciao-prolog@master
+#         uses: logtalk-actions/setup-scryer-prolog@master
 #         with:
-#           ciao-prolog-version: latest
-#       - if: matrix.backend == 'cx-prolog'
+#           scryer-prolog-version: latest
+#       - if: matrix.backend == 'b-prolog'
 #         name: Install backend
-#         uses: logtalk-actions/setup-cx-prolog@master
+#         uses: logtalk-actions/setup-b-prolog@master
 #         with:
-#           cx-prolog-version: latest
+#           b-prolog-version: latest
+#
+#       See issue: https://github.com/logtalk-actions/setup-jiprolog/issues/3 
+#
 #       - if: matrix.backend == 'jip-prolog'
 #         name: Install backend
 #         uses: logtalk-actions/setup-jiprolog@master
 #         with:
 #           jip-prolog-version: latest
-#       - if: matrix.backend == 'lvm-prolog'
+#
+#       These two exist in Logtalk CI, but fail:
+#
+#       - if: matrix.backend == 'tau-prolog'
 #         name: Install backend
-#         uses: logtalk-actions/setup-lvm-prolog@master
+#         uses: logtalk-actions/setup-tau-prolog@master
 #         with:
-#           lvm-prolog-version: latest
-#       - if: matrix.backend == 'quintus-prolog'
+#           tau-prolog-version: latest 
+#       - if: matrix.backend == 'trealla-prolog'
 #         name: Install backend
-#         uses: logtalk-actions/setup-quintus-prolog@master
+#         uses: logtalk-actions/setup-trealla-prolog@master
 #         with:
-#           quintus-prolog-version: latest 
-#       - if: matrix.backend == 'sicstus-prolog'
-#         name: Install backend
-#         uses: logtalk-actions/setup-sicstus-prolog@master
-#         with:
-#           sicstus-prolog-version: latest 
-      - if: matrix.backend == 'tau-prolog'
-        name: Install backend
-        uses: logtalk-actions/setup-tau-prolog@master
-        with:
-          tau-prolog-version: latest 
-      - if: matrix.backend == 'trealla-prolog'
-        name: Install backend
-        uses: logtalk-actions/setup-trealla-prolog@master
-        with:
-          trealla-prolog-version: latest 
-#       - if: matrix.backend == 'xsb-prolog'
-#         name: Install backend
-#         uses: logtalk-actions/setup-xsb-prolog@master
-#         with:
-#           xsb-prolog-version: latest 
-#       - if: matrix.backend == 'yap-prolog'
-#         name: Install backend
-#         uses: logtalk-actions/setup-yap-prolog@master
-#         with:
-#           yap-prolog-version: latest
-#       - name: Set Actions Allow Unsecure Commands
-#         run: |
-#                  echo "ACTIONS_ALLOW_UNSECURE_COMMANDS=true" >> $GITHUB_ENV
+#           trealla-prolog-version: latest 
       - name: Install Logtalk
         uses: logtalk-actions/setup-logtalk@master
         with:
@@ -99,6 +69,9 @@ jobs:
         uses: actions/checkout@v1
         with:
           fetch-depth: 1
+#     - name: Set Actions Allow Unsecure Commands
+#         run: |
+#                  echo "ACTIONS_ALLOW_UNSECURE_COMMANDS=true" >> $GITHUB_ENV
       - name: Define environment variable for the test results
         run: echo "DEPLOYMENT_STATUS=skipped" >> $GITHUB_ENV # Taken from https://github.com/JamesIves/github-pages-deploy-action/issues/500#issuecomment-728375894
       - name: Run the application tests
@@ -111,11 +84,11 @@ jobs:
         uses: actions/upload-artifact@master
         with:
           name: ${{ matrix.backend }}-xunit-report
-          path: xunit_report.html
+          path: $(basename $GITHUB_REPOSITORY)/xunit_reports/xunit_report.html
       - name: Upload code coverage report
         uses: actions/upload-artifact@master
         with:
           name: ${{ matrix.backend }}-code-coverage-report
-          path: coverage_report.html
+          path: $(basename $GITHUB_REPOSITORY)/coverage_reports/coverage_report.html
       - name: Set workflow exit status after the test results
         run: exit $EXIT

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -84,11 +84,11 @@ jobs:
         uses: actions/upload-artifact@master
         with:
           name: ${{ matrix.backend }}-xunit-report
-          path: $(basename $GITHUB_REPOSITORY)/xunit_reports/xunit_report.html
+          path: xunit_report.html
       - name: Upload code coverage report
         uses: actions/upload-artifact@master
         with:
           name: ${{ matrix.backend }}-code-coverage-report
-          path: $(basename $GITHUB_REPOSITORY)/coverage_reports/coverage_report.html
+          path: coverage_report.html
       - name: Set workflow exit status after the test results
         run: exit $EXIT

--- a/NOTES.md
+++ b/NOTES.md
@@ -43,9 +43,14 @@ To run the tests type:
 ## Supported Prolog backends
 - [x] SWI-Prolog (threaded, 64 bits, version 8.5.5-3-gb856d332c-DIRTY), works ([see](https://github.com/mlliarm/ia/issues/10#issuecomment-1009255385)).
 - [x] GNU-Prolog 1.5.0 (64 bits), works ([see](https://github.com/mlliarm/ia/issues/10#issuecomment-1009268552)).
+- [X] ECLiPSe 7.0_54, works.
 
-## Know issues
+## Known issues
 - Ciao Prolog (tested with version 1.20.0) cannot be used due to lack of support for the `min/2` and `max/2` arithmetic functions.
+- B-Prolog v8.1 testing during CI crashes with [this](https://github.com/mlliarm/ia/issues/21) error.
+- Tau-Prolog crashes during CI with [this](https://github.com/mlliarm/ia/issues/20) error and it seems that it cannot see the test suite.
+- Scryer-Prolog v0.8.127 crashes during CI with [this](https://github.com/mlliarm/ia/issues/22) error.
+- Crealla-Prolog latest version crashes during CI with [this](https://github.com/mlliarm/ia/issues/23) error.
 
 ## Node coverage
 - One (1) entity declared as covered containing 20 clauses.


### PR DESCRIPTION
Issues fixed.

Library works with Eclipse Prolog, SWI-Prolog, GNU-Prolog.

Fails with the rest, see issues #20, #21, #22, #23.